### PR TITLE
upgrade postgres:10.13-alpine

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.4-alpine
+FROM postgres:10.13-alpine
 
 ENV DEFAULT_TIMEZONE UTC
 


### PR DESCRIPTION
Use PostgreSQL 10.13 (Alpine Linux) Image.

**Please backup and restore before run this Compose file using PostgreSQL v9.**